### PR TITLE
upgrade node version to 18

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     build-essential \
     libpq-dev \
     git
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - &&\
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
     apt-get install -y nodejs
 
 USER airflow


### PR DESCRIPTION
trackdechet search uses node 18 after https://github.com/MTES-MCT/trackdechets/pull/2361/files